### PR TITLE
Bump ffi in Gemfile.lock to 1.17.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,8 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.3)
-    ffi (1.17.3-x86_64-linux)
+    ffi (1.17.5)
+    ffi (1.17.5-x86_64-linux)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)


### PR DESCRIPTION
### Motivation
- The project’s `bundle install` was failing because the lock referenced `ffi (1.17.3)`, which has been removed from the source, and a previous bump to `1.17.4` did not resolve the failure. 
- The lockfile needs to reference an available `ffi` release so CI can restore the bundler cache and complete the Pages build.

### Description
- Updated the `ffi` entries in `Gemfile.lock` to `1.17.5` and the platform-specific entry to `1.17.5-x86_64-linux` to point to a version available from RubyGems. 
- Replaced the older `ffi` lines so dependent gems that require `ffi (>= 1.15.0)` can resolve correctly. 

### Testing
- No automated tests were run for this lockfile-only change; please trigger the CI workflow to confirm that `bundle install` and the GitHub Pages build succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ae644bc4832189c8c62ba75752da)