### PR TITLE
Update `ffi` in Gemfile.lock to 1.17.6 for Pages build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          cache-version: 1 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,8 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.4)
-    ffi (1.17.4-x86_64-linux)
+    ffi (1.17.6)
+    ffi (1.17.6-x86_64-linux)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)


### PR DESCRIPTION
### Motivation

- CI `bundle install` is failing because the lockfile referenced an `ffi` version that has been removed from RubyGems, blocking GitHub Pages builds.

### Description

- Updated `Gemfile.lock` to pin `ffi` and its platform variant to `1.17.6` so Bundler can install an available release.
- This change is a lockfile-only fix; the earlier workflow cache bump (`cache-version` -> `1`) remains from the prior change.

### Testing

- A prior GitHub Actions run failed during `bundle install` with exit code `7` because `ffi (1.17.5)` could not be found in the source. 
- No automated tests were run after this lockfile update; the next CI run (GitHub Actions) is expected to validate whether the update resolves the bundler failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e9c29cf483219df1198a9768ad8b)